### PR TITLE
feat(viewer): add join confirmation dialog with rate and cost preview

### DIFF
--- a/frontend/room.html
+++ b/frontend/room.html
@@ -111,6 +111,39 @@
       </div>
     </div>
 
+    <!-- Join confirmation overlay (viewer-only) -->
+    <div id="join-confirm-overlay" class="hidden" role="alertdialog" aria-modal="true" aria-labelledby="join-confirm-title">
+      <div class="join-confirm-card">
+        <h2 id="join-confirm-title">Confirm Join</h2>
+        <p class="join-confirm-intro">The streamer is charging:</p>
+        <div class="join-confirm-rate-hero">
+          <span id="join-confirm-rate"></span>
+          <span class="join-confirm-rate-per-min" id="join-confirm-rate-per-min"></span>
+        </div>
+        <div class="join-confirm-details">
+          <div class="join-confirm-row">
+            <span class="label">Your balance</span>
+            <span class="value" id="join-confirm-balance">—</span>
+          </div>
+          <div class="join-confirm-row">
+            <span class="label">Watch time</span>
+            <span class="value" id="join-confirm-duration">—</span>
+          </div>
+          <div class="join-confirm-row join-confirm-mint-row">
+            <span class="label">Mint</span>
+            <span class="value mint"><code id="join-confirm-mint">—</code></span>
+          </div>
+        </div>
+        <p class="join-confirm-fine-print">
+          You will only be charged after you accept and the session starts. Cancel to return home — nothing will be charged.
+        </p>
+        <div class="join-confirm-actions">
+          <button id="join-confirm-cancel" type="button" class="btn-join-cancel">Cancel</button>
+          <button id="join-confirm-accept" type="button" class="btn-join-accept">Accept &amp; Join</button>
+        </div>
+      </div>
+    </div>
+
     <!-- Mint mismatch blocking overlay (viewer-only) -->
     <div id="mint-mismatch-overlay" class="hidden" role="alertdialog" aria-modal="true" aria-labelledby="mint-mismatch-title">
       <div class="mint-mismatch-card">

--- a/frontend/src/pages/viewer.ts
+++ b/frontend/src/pages/viewer.ts
@@ -5,7 +5,7 @@ import { DataChannel } from '../lib/data-channel.js';
 import { preSplitProofs } from '../lib/cashu-wallet.js';
 import { PaymentScheduler } from '../lib/payment-scheduler.js';
 import type { SignalingMessage } from '../types/signaling.js';
-import { saveSession, loadSession, updateSession } from '../lib/session-storage.js';
+import { saveSession, loadSession, updateSession, clearSession } from '../lib/session-storage.js';
 import { assertSameMint, MintMismatchError } from '../lib/mint-guard.js';
 import { getBalance, onBalanceChange, spendProofs } from '../lib/wallet-store.js';
 import { getMintUrl } from '../lib/config.js';
@@ -50,6 +50,16 @@ const exitSessionBtnEl = document.getElementById('exit-session-btn') as HTMLButt
 const budgetLowBannerEl = document.getElementById('budget-low-banner');
 const budgetLowTextEl = document.getElementById('budget-low-text');
 const countdownDisplayEl = document.getElementById('countdown-display');
+
+// Join confirmation overlay
+const joinConfirmOverlayEl = document.getElementById('join-confirm-overlay');
+const joinConfirmRateEl = document.getElementById('join-confirm-rate');
+const joinConfirmRatePerMinEl = document.getElementById('join-confirm-rate-per-min');
+const joinConfirmBalanceEl = document.getElementById('join-confirm-balance');
+const joinConfirmDurationEl = document.getElementById('join-confirm-duration');
+const joinConfirmMintEl = document.getElementById('join-confirm-mint');
+const joinConfirmAcceptBtn = document.getElementById('join-confirm-accept') as HTMLButtonElement | null;
+const joinConfirmCancelBtn = document.getElementById('join-confirm-cancel') as HTMLButtonElement | null;
 
 function showMintMismatch(sessionMint: string, localMint: string): void {
   if (sessionMintUrlEl !== null) sessionMintUrlEl.textContent = sessionMint;
@@ -248,19 +258,126 @@ let activeRateSatsPerInterval = DEFAULT_RATE_SATS;
 let activeIntervalSeconds = DEFAULT_INTERVAL_SECS;
 
 // Pre-populate from pending_join invite data if available (set by home.ts)
+let invitedRate: number | null = null;
+let invitedInterval: number | null = null;
+let invitedMintUrl: string | null = null;
+
 try {
   const pendingJoinRaw = sessionStorage.getItem('pending_join');
   if (pendingJoinRaw !== null) {
     const pendingJoin = JSON.parse(pendingJoinRaw) as Record<string, unknown>;
     if (typeof pendingJoin['rateSatsPerInterval'] === 'number') {
       activeRateSatsPerInterval = pendingJoin['rateSatsPerInterval'] as number;
+      invitedRate = activeRateSatsPerInterval;
     }
     if (typeof pendingJoin['intervalSeconds'] === 'number') {
       activeIntervalSeconds = pendingJoin['intervalSeconds'] as number;
+      invitedInterval = activeIntervalSeconds;
+    }
+    if (typeof pendingJoin['mintUrl'] === 'string') {
+      invitedMintUrl = pendingJoin['mintUrl'] as string;
     }
   }
 } catch {
   // sessionStorage read/parse failures are non-fatal
+}
+
+// ---------------------------------------------------------------------------
+// Join confirmation gate
+//
+// The viewer must explicitly accept the streamer's rate before any session
+// setup happens (camera/mic prompt, pre-split, offer/answer, scheduler). The
+// dialog is shown as soon as rate info is known — either from the invite
+// (pending_join) on page load, or from the first session_created signaling
+// message for a manual join.
+// ---------------------------------------------------------------------------
+
+let joinConfirmShown = false;
+let joinDecisionResolve: ((accepted: boolean) => void) | null = null;
+const joinDecisionPromise = new Promise<boolean>((resolve) => {
+  joinDecisionResolve = resolve;
+});
+
+function populateJoinConfirm(rate: number, interval: number, dialogMintUrl: string | null): void {
+  if (joinConfirmRateEl !== null) {
+    joinConfirmRateEl.innerHTML =
+      `<strong>${rate}</strong> <span class="sat">S</span> every <strong>${interval}</strong>s`;
+  }
+  if (joinConfirmRatePerMinEl !== null) {
+    if (interval > 0) {
+      const perMin = (rate * 60) / interval;
+      const formatted = Number.isInteger(perMin) ? String(perMin) : perMin.toFixed(1);
+      joinConfirmRatePerMinEl.innerHTML = `= ${formatted} <span class="sat">S</span>/min`;
+    } else {
+      joinConfirmRatePerMinEl.textContent = '';
+    }
+  }
+  const balance = getBalance();
+  if (joinConfirmBalanceEl !== null) {
+    joinConfirmBalanceEl.innerHTML = `${balance.toLocaleString()} <span class="sat">S</span>`;
+  }
+  if (joinConfirmDurationEl !== null) {
+    if (rate > 0 && interval > 0 && balance > 0) {
+      const totalSeconds = Math.floor(balance / rate) * interval;
+      if (totalSeconds >= 60) {
+        const mins = Math.floor(totalSeconds / 60);
+        const secs = totalSeconds % 60;
+        joinConfirmDurationEl.textContent =
+          secs > 0 ? `~${mins} min ${secs}s` : `~${mins} min`;
+      } else {
+        joinConfirmDurationEl.textContent = `~${totalSeconds}s`;
+      }
+    } else if (balance === 0) {
+      joinConfirmDurationEl.innerHTML = '<span class="warn">0 — deposit first</span>';
+    } else {
+      joinConfirmDurationEl.textContent = '—';
+    }
+  }
+  if (joinConfirmMintEl !== null) {
+    joinConfirmMintEl.textContent = dialogMintUrl ?? mintUrl;
+  }
+}
+
+function showJoinConfirm(rate: number, interval: number, dialogMintUrl: string | null): void {
+  if (joinConfirmShown) return;
+  joinConfirmShown = true;
+  populateJoinConfirm(rate, interval, dialogMintUrl);
+  if (joinConfirmOverlayEl !== null) {
+    joinConfirmOverlayEl.classList.remove('hidden');
+  }
+  joinConfirmAcceptBtn?.focus();
+}
+
+function hideJoinConfirm(): void {
+  if (joinConfirmOverlayEl !== null) {
+    joinConfirmOverlayEl.classList.add('hidden');
+  }
+}
+
+function resolveJoinDecision(accepted: boolean): void {
+  const resolve = joinDecisionResolve;
+  joinDecisionResolve = null;
+  if (resolve !== null) resolve(accepted);
+}
+
+if (joinConfirmAcceptBtn !== null) {
+  joinConfirmAcceptBtn.addEventListener('click', () => {
+    hideJoinConfirm();
+    resolveJoinDecision(true);
+  });
+}
+
+if (joinConfirmCancelBtn !== null) {
+  joinConfirmCancelBtn.addEventListener('click', () => {
+    hideJoinConfirm();
+    resolveJoinDecision(false);
+  });
+}
+
+// If the invite carried rate info, show the dialog before opening the
+// signaling socket so the viewer sees the cost before any session setup.
+if (invitedRate !== null && invitedInterval !== null) {
+  showJoinConfirm(invitedRate, invitedInterval, invitedMintUrl);
 }
 
 // ---------------------------------------------------------------------------
@@ -296,7 +413,11 @@ client.onConnect(() => {
     return;
   }
 
-  ui.setStatus('connected -- joining session\u2026');
+  ui.setStatus(
+    joinConfirmShown
+      ? 'connected -- awaiting your confirmation\u2026'
+      : 'connected -- loading session info\u2026',
+  );
   client.send({ type: 'join_session', sessionId });
 
   // Persist session state for reconnect recovery
@@ -311,24 +432,53 @@ client.onConnect(() => {
     );
   }
 
-  const existing = loadSession();
-  const isSameSession = existing !== null && existing.sessionId === sessionId;
-  saveSession({
-    sessionId,
-    peerId: isSameSession ? (existing.peerId ?? '') : '',
-    role: 'viewer',
-    chunkCount: isSameSession ? (existing.chunkCount ?? 0) : 0,
-    totalSatsPaid: isSameSession ? (existing.totalSatsPaid ?? 0) : 0,
-  });
-
-  // Start media in parallel with session join
-  void sharedStartMedia(peer, localVideoEl, ui.showError).then((stream) => {
-    localStream = stream;
-    if (stream !== null) {
-      console.log('[viewer] local media ready');
+  // All further setup (media prompt, session persistence) is gated on the
+  // viewer accepting the rate in the confirmation dialog.
+  void joinDecisionPromise.then((accepted) => {
+    if (!accepted) {
+      handleCancelledJoin();
+      return;
     }
+
+    // Persist session state only after acceptance so a cancelled join does
+    // not leave a phantom entry in localStorage.
+    const existing = loadSession();
+    const isSameSession = existing !== null && existing.sessionId === sessionId;
+    saveSession({
+      sessionId,
+      peerId: isSameSession ? (existing.peerId ?? '') : '',
+      role: 'viewer',
+      chunkCount: isSameSession ? (existing.chunkCount ?? 0) : 0,
+      totalSatsPaid: isSameSession ? (existing.totalSatsPaid ?? 0) : 0,
+    });
+
+    ui.setStatus('joining session…');
+    void sharedStartMedia(peer, localVideoEl, ui.showError).then((stream) => {
+      localStream = stream;
+      if (stream !== null) {
+        console.log('[viewer] local media ready');
+      }
+    });
   });
 });
+
+function handleCancelledJoin(): void {
+  console.log('[viewer] user cancelled join — tearing down');
+  ui.setStatus('cancelled');
+  scheduler?.stop();
+  if (sessionId !== null) {
+    // Safe even if the socket is not open — sendRaw guards against that.
+    client.send({ type: 'end_session', sessionId });
+  }
+  client.disconnect();
+  clearSession();
+  try {
+    sessionStorage.removeItem('pending_join');
+  } catch {
+    // sessionStorage may be unavailable — non-fatal
+  }
+  window.location.href = '/';
+}
 
 client.onDisconnecting(() => {
   ui.showReconnectOverlay();
@@ -487,14 +637,27 @@ client.onMessage((msg: SignalingMessage) => {
         activeIntervalSeconds = msg.intervalSeconds;
       }
       console.log('[viewer] rate config:', activeRateSatsPerInterval, 'sats /', activeIntervalSeconds, 's');
-      // Pre-split proofs into exact-denomination chunks before the session starts.
-      ui.setStatus('preparing wallet\u2026');
-      void preSplitProofs(activeRateSatsPerInterval, getBalance()).then((numChunks) => {
-        console.log(`[viewer] pre-split complete: ${numChunks} chunks of ${activeRateSatsPerInterval} sats`);
-        ui.setStatus('wallet ready — waiting for tutor\u2026');
-      }).catch((err: unknown) => {
-        const reason = err instanceof Error ? err.message : String(err);
-        ui.showError(`Pre-split failed: ${reason}`);
+
+      // Manual-entry flow: no invite data on page load, so the confirmation
+      // dialog could not be shown yet. Show it now with the authoritative
+      // rate from the signaling server.
+      if (!joinConfirmShown) {
+        showJoinConfirm(activeRateSatsPerInterval, activeIntervalSeconds, msg.mintUrl);
+      }
+
+      // Pre-split is gated on the viewer accepting the rate. If they cancel,
+      // the `onConnect` handler tears down the session — we just no-op here.
+      void joinDecisionPromise.then((accepted) => {
+        if (!accepted) return;
+        // Pre-split proofs into exact-denomination chunks before the session starts.
+        ui.setStatus('preparing wallet\u2026');
+        void preSplitProofs(activeRateSatsPerInterval, getBalance()).then((numChunks) => {
+          console.log(`[viewer] pre-split complete: ${numChunks} chunks of ${activeRateSatsPerInterval} sats`);
+          ui.setStatus('wallet ready — waiting for tutor\u2026');
+        }).catch((err: unknown) => {
+          const reason = err instanceof Error ? err.message : String(err);
+          ui.showError(`Pre-split failed: ${reason}`);
+        });
       });
       break;
 
@@ -530,6 +693,14 @@ client.onMessage((msg: SignalingMessage) => {
 async function handleOffer(offer: RTCSessionDescriptionInit): Promise<void> {
   if (sessionId === null) {
     ui.showError('Offer received but no sessionId');
+    return;
+  }
+
+  // Do not answer the offer until the viewer has accepted the rate. A
+  // cancelled join short-circuits the rest of the handshake here.
+  const accepted = await joinDecisionPromise;
+  if (!accepted) {
+    console.log('[viewer] offer ignored — viewer cancelled join');
     return;
   }
 

--- a/frontend/src/styles/session.css
+++ b/frontend/src/styles/session.css
@@ -1135,3 +1135,222 @@ html {
   border: 1px solid rgba(16, 217, 160, 0.35);
   color: var(--color-success);
 }
+
+/* ------------------------------------------------------------
+   Join confirmation blocking overlay
+   ------------------------------------------------------------ */
+
+#join-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 15000;
+  background: rgba(5, 7, 15, 0.85);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  animation: join-confirm-fade 200ms var(--ease-out) both;
+}
+
+#join-confirm-overlay.hidden {
+  display: none;
+}
+
+@keyframes join-confirm-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.join-confirm-card {
+  position: relative;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-xl);
+  padding: 1.75rem 2rem 1.75rem;
+  max-width: 460px;
+  width: 100%;
+  box-shadow: var(--shadow-modal);
+  overflow: hidden;
+  animation: join-confirm-slide-up var(--duration-slow) var(--ease-out) both;
+}
+
+.join-confirm-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--gradient-brand);
+}
+
+@keyframes join-confirm-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.join-confirm-card h2 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-2xl);
+  font-weight: 800;
+  color: var(--color-text-primary);
+  text-align: center;
+}
+
+.join-confirm-intro {
+  margin: 0 0 var(--space-4);
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.join-confirm-rate-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-4) var(--space-3);
+  background: var(--gradient-brand-subtle);
+  border: 1px solid var(--color-border-accent);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-5);
+}
+
+#join-confirm-rate {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+#join-confirm-rate strong {
+  color: var(--color-bitcoin);
+  font-weight: 800;
+}
+
+.join-confirm-rate-per-min {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.join-confirm-details {
+  border-top: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding: var(--space-2) 0;
+  margin-bottom: var(--space-4);
+}
+
+.join-confirm-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4rem 0;
+  gap: var(--space-3);
+}
+
+.join-confirm-row .label {
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.join-confirm-row .value {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--color-text-accent);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-sm);
+}
+
+.join-confirm-mint-row .value {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  word-break: break-all;
+  text-align: right;
+  min-width: 0;
+  font-weight: 400;
+}
+
+.join-confirm-mint-row .value code {
+  font-family: var(--font-mono);
+  background: transparent;
+}
+
+.join-confirm-row .value .warn {
+  color: var(--color-warning);
+  font-weight: 600;
+}
+
+.join-confirm-fine-print {
+  margin: 0 0 var(--space-5);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.join-confirm-actions {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.join-confirm-actions button {
+  flex: 1;
+  padding: 0.65rem var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+  font-weight: 600;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    transform var(--duration-fast) var(--ease-out),
+    filter var(--duration-fast) ease;
+}
+
+.btn-join-cancel {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-default);
+}
+
+.btn-join-cancel:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-border-accent);
+  background: var(--color-bg-overlay);
+}
+
+.btn-join-accept {
+  background: var(--gradient-brand);
+  color: #fff;
+  border: none;
+  box-shadow: var(--shadow-glow-bitcoin);
+}
+
+.btn-join-accept:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.1);
+}
+
+.btn-join-accept:active {
+  transform: scale(0.98);
+}
+
+.btn-join-accept:focus-visible,
+.btn-join-cancel:focus-visible {
+  outline: 2px solid var(--color-bitcoin);
+  outline-offset: 3px;
+}


### PR DESCRIPTION
## Summary
- Before joining a session, viewers now see an alertdialog showing the tutor's rate, their current Cashu balance, and an estimated watch duration.
- Accept continues into the room as before; Cancel tears down the connection, clears pending session state, and returns to the home page — no media is captured and no payment pre-split occurs unless the viewer accepts.
- Dialog opens immediately when arriving via an invite link (rate is in `pending_join`) and after `session_created` when a viewer enters a session ID manually.

## Motivation
Previously a viewer could be invited to a room and connected (triggering camera/mic prompts and a pre-split of ecash) without ever being shown the price the streamer is charging. A malicious or careless streamer could set an exorbitant rate or aggressive payment cadence. This dialog surfaces the cost before any commitment.

## Implementation notes
- Single `joinDecisionPromise` gates three points: `getUserMedia`, `saveSession` + pre-split, and `handleOffer`'s answer send.
- `handleCancelledJoin` sends `end_session`, disconnects the signaling client, clears stored session, removes `pending_join`, and navigates to `/`.
- Styling follows the existing dark/glass design tokens; hero panel uses the brand gradient.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 69/69 pass
- [ ] Manual: invite link flow shows dialog immediately with correct rate, balance, and duration
- [ ] Manual: manual session-ID entry shows dialog after signaling round-trip
- [ ] Manual: Accept path joins normally and streaming/payments work
- [ ] Manual: Cancel path returns to home, no camera prompt, no phantom saved session, no `pending_join` left behind
- [ ] Manual: mint-mismatch overlay still blocks correctly when mints differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)